### PR TITLE
Performance improvements batch 2

### DIFF
--- a/addons/lit/runtime/lit_light_registry.gd
+++ b/addons/lit/runtime/lit_light_registry.gd
@@ -34,6 +34,17 @@ var _dummy: ImageTexture
 var _tile_header_tex: ImageTexture
 var _tile_index_tex: ImageTexture
 
+# Reused scratch for the tile grid, kept across frames. Header/index data is written into
+# the float buffers and uploaded via create_from_data/set_data. _tile_counts/_tile_offsets/
+# _tile_spans drive a counting sort: tally per tile, prefix-sum to offsets, scatter rows.
+var _tile_header_img: Image
+var _tile_index_img: Image
+var _tile_header_buf: PackedFloat32Array = PackedFloat32Array()
+var _tile_index_buf: PackedFloat32Array = PackedFloat32Array()
+var _tile_counts: PackedInt32Array = PackedInt32Array()
+var _tile_offsets: PackedInt32Array = PackedInt32Array()
+var _tile_spans: PackedInt32Array = PackedInt32Array()
+
 # Reused scratch for packing: write floats straight into _pack_buf and upload once,
 # instead of per-texel Image.set_pixel calls. _pack_img is kept across frames and only
 # reallocated when the light count changes.
@@ -281,27 +292,33 @@ func _pack_spot(row: int, light: LitSpotLight2D, canvas_xform: Transform2D, vp_s
 ## shader reads its own tile's header and shades only those rows. Directionals are skipped
 ## (they're full-screen and shaded directly).
 func _build_tiles(visible: Array, canvas_xform: Transform2D, vp_size: Vector2) -> void:
-	var tiles_x := int(ceil(vp_size.x / float(TILE_SIZE)))
-	var tiles_y := int(ceil(vp_size.y / float(TILE_SIZE)))
-	tiles_x = max(tiles_x, 1)
-	tiles_y = max(tiles_y, 1)
+	var tiles_x := maxi(int(ceil(vp_size.x / float(TILE_SIZE))), 1)
+	var tiles_y := maxi(int(ceil(vp_size.y / float(TILE_SIZE))), 1)
 	var tile_count := tiles_x * tiles_y
 
-	# One index bucket per tile, filled with the rows of the lights that reach it.
-	var buckets: Array = []
-	buckets.resize(tile_count)
-	for t in tile_count:
-		buckets[t] = PackedInt32Array()
+	# Per-tile entry counts (how many lights touch each tile), reused across frames.
+	if _tile_counts.size() != tile_count:
+		_tile_counts.resize(tile_count)
+	_tile_counts.fill(0)
 
 	# World range to screen pixels. Use the larger canvas-basis axis so a zoomed or
 	# non-uniformly scaled view over-includes rather than clips a light's footprint.
-	var sx := canvas_xform.x.length()
-	var sy := canvas_xform.y.length()
-	var scale := maxf(sx, sy)
+	var scale := maxf(canvas_xform.x.length(), canvas_xform.y.length())
 
-	for i in visible.size():
-		# Directionals aren't tiled; the shader sweeps them for every fragment.
+	# Per-light clamped tile span, computed once here and reused by the scatter pass below.
+	# Four ints per light: tx0 | tx1 | ty0 | ty1. Directionals (and any empty span) are
+	# marked tx0 > tx1 so the scatter pass skips them without another type check.
+	var n := visible.size()
+	if _tile_spans.size() != n * 4:
+		_tile_spans.resize(n * 4)
+
+	# Pass 1: tally how many lights land in each tile, recording each light's span.
+	for i in n:
+		var so := i * 4
 		if visible[i] is LitDirectionalLight2D:
+			# Directionals aren't tiled; the shader sweeps them for every fragment.
+			_tile_spans[so] = 1      # tx0 > tx1 marks "skip"
+			_tile_spans[so + 1] = 0
 			continue
 
 		# range lives on each positional light type; fetch it dynamically.
@@ -310,45 +327,68 @@ func _build_tiles(visible: Array, canvas_xform: Transform2D, vp_size: Vector2) -
 		var light_range: float = float(light.get("range")) * scale
 
 		# Tile span of the light's screen AABB, clamped to the grid.
-		var tx0 := int(floor((center.x - light_range) / float(TILE_SIZE)))
-		var tx1 := int(floor((center.x + light_range) / float(TILE_SIZE)))
-		var ty0 := int(floor((center.y - light_range) / float(TILE_SIZE)))
-		var ty1 := int(floor((center.y + light_range) / float(TILE_SIZE)))
-		tx0 = clampi(tx0, 0, tiles_x - 1)
-		tx1 = clampi(tx1, 0, tiles_x - 1)
-		ty0 = clampi(ty0, 0, tiles_y - 1)
-		ty1 = clampi(ty1, 0, tiles_y - 1)
+		var tx0 := clampi(int(floor((center.x - light_range) / float(TILE_SIZE))), 0, tiles_x - 1)
+		var tx1 := clampi(int(floor((center.x + light_range) / float(TILE_SIZE))), 0, tiles_x - 1)
+		var ty0 := clampi(int(floor((center.y - light_range) / float(TILE_SIZE))), 0, tiles_y - 1)
+		var ty1 := clampi(int(floor((center.y + light_range) / float(TILE_SIZE))), 0, tiles_y - 1)
+		_tile_spans[so] = tx0
+		_tile_spans[so + 1] = tx1
+		_tile_spans[so + 2] = ty0
+		_tile_spans[so + 3] = ty1
 
 		for ty in range(ty0, ty1 + 1):
 			var row_base := ty * tiles_x
 			for tx in range(tx0, tx1 + 1):
-				buckets[row_base + tx].push_back(i)
+				_tile_counts[row_base + tx] += 1
 
-	# Header is one texel per tile; the index list is INDEX_TEX_WIDTH-wide and as many
-	# rows as it takes to hold every (tile, light) entry.
-	var header_img := Image.create(tiles_x, tiles_y, false, Image.FORMAT_RGBAF)
-	var total_indices := 0
-	for t in tile_count:
-		total_indices += buckets[t].size()
-
-	var idx_rows := int(ceil(float(maxi(total_indices, 1)) / float(INDEX_TEX_WIDTH)))
-	var index_img := Image.create(INDEX_TEX_WIDTH, idx_rows, false, Image.FORMAT_RGBAF)
-
-	# Lay buckets out contiguously: each tile's header records its start offset and count.
+	# Prefix-sum the counts into per-tile start offsets and write the header texel
+	# (offset | count) for each tile. _tile_offsets doubles as the scatter cursor below.
+	if _tile_header_buf.size() != tile_count * 4:
+		_tile_header_buf.resize(tile_count * 4)
+	if _tile_offsets.size() != tile_count:
+		_tile_offsets.resize(tile_count)
 	var offset := 0
 	for t in tile_count:
-		var bucket: PackedInt32Array = buckets[t]
-		var cnt := bucket.size()
-		var hx := t % tiles_x
-		var hy := t / tiles_x
-		header_img.set_pixel(hx, hy, Color(float(offset), float(cnt), 0.0, 0.0))
-		for j in cnt:
-			var flat := offset + j
-			index_img.set_pixel(flat % INDEX_TEX_WIDTH, flat / INDEX_TEX_WIDTH, Color(float(bucket[j]), 0.0, 0.0, 0.0))
+		var cnt := _tile_counts[t]
+		_tile_offsets[t] = offset
+		var ho := t * 4
+		_tile_header_buf[ho] = float(offset)
+		_tile_header_buf[ho + 1] = float(cnt)
+		_tile_header_buf[ho + 2] = 0.0
+		_tile_header_buf[ho + 3] = 0.0
 		offset += cnt
+	var total_indices := offset
 
-	_tile_header_tex = _make_or_update(_tile_header_tex, header_img)
-	_tile_index_tex = _make_or_update(_tile_index_tex, index_img)
+	# Flat index list: INDEX_TEX_WIDTH-wide, as many rows as it takes. Only each texel's
+	# .r is read, and only within a tile's [offset, offset+count) range; every such slot
+	# is written by the scatter below, so the buffer needs no clearing.
+	var idx_rows := int(ceil(float(maxi(total_indices, 1)) / float(INDEX_TEX_WIDTH)))
+	if _tile_index_buf.size() != INDEX_TEX_WIDTH * idx_rows * 4:
+		_tile_index_buf.resize(INDEX_TEX_WIDTH * idx_rows * 4)
+
+	# Pass 2: scatter each positional light's row into its tiles, advancing the cursor.
+	# A flat index maps to RGBAF float-buffer slot flat * 4 (the texel's .r channel).
+	for i in n:
+		var so := i * 4
+		var tx0 := _tile_spans[so]
+		var tx1 := _tile_spans[so + 1]
+		if tx0 > tx1:
+			continue
+		var ty0 := _tile_spans[so + 2]
+		var ty1 := _tile_spans[so + 3]
+		for ty in range(ty0, ty1 + 1):
+			var row_base := ty * tiles_x
+			for tx in range(tx0, tx1 + 1):
+				var t := row_base + tx
+				var pos := _tile_offsets[t]
+				_tile_offsets[t] = pos + 1
+				_tile_index_buf[pos * 4] = float(i)
+
+	# Upload via reused Image/ImageTexture.
+	_tile_header_img = _image_from_floats(_tile_header_img, tiles_x, tiles_y, _tile_header_buf)
+	_tile_index_img = _image_from_floats(_tile_index_img, INDEX_TEX_WIDTH, idx_rows, _tile_index_buf)
+	_tile_header_tex = _make_or_update(_tile_header_tex, _tile_header_img)
+	_tile_index_tex = _make_or_update(_tile_index_tex, _tile_index_img)
 
 	RenderingServer.global_shader_parameter_set("lit_tile_size", TILE_SIZE)
 	RenderingServer.global_shader_parameter_set("lit_tile_grid", Vector2i(tiles_x, tiles_y))
@@ -358,8 +398,8 @@ func _build_tiles(visible: Array, canvas_xform: Transform2D, vp_size: Vector2) -
 ## Publish a valid but empty tile grid (all counts zero) for the zero-light case, so the
 ## shader's tiling path stays valid and simply shades nothing.
 func _publish_empty_tiles(vp_size: Vector2) -> void:
-	var tiles_x := max(int(ceil(vp_size.x / float(TILE_SIZE))), 1)
-	var tiles_y := max(int(ceil(vp_size.y / float(TILE_SIZE))), 1)
+	var tiles_x := maxi(int(ceil(vp_size.x / float(TILE_SIZE))), 1)
+	var tiles_y := maxi(int(ceil(vp_size.y / float(TILE_SIZE))), 1)
 	var header_img := Image.create(tiles_x, tiles_y, false, Image.FORMAT_RGBAF)
 	header_img.fill(Color(0.0, 0.0, 0.0, 0.0))
 	var index_img := Image.create(INDEX_TEX_WIDTH, 1, false, Image.FORMAT_RGBAF)
@@ -371,6 +411,16 @@ func _publish_empty_tiles(vp_size: Vector2) -> void:
 	RenderingServer.global_shader_parameter_set("lit_tile_grid", Vector2i(tiles_x, tiles_y))
 	RenderingServer.global_shader_parameter_set("lit_tile_headers", _tile_header_tex)
 	RenderingServer.global_shader_parameter_set("lit_tile_indices", _tile_index_tex)
+
+## Build or refresh a width x height RGBAF Image from a float buffer, reusing the Image
+## across frames and only reallocating when the dimensions change. The buffer must hold
+## width * height * 4 floats (RGBA row-major).
+func _image_from_floats(img: Image, width: int, height: int, buf: PackedFloat32Array) -> Image:
+	var bytes := buf.to_byte_array()
+	if img == null or img.get_width() != width or img.get_height() != height:
+		return Image.create_from_data(width, height, false, Image.FORMAT_RGBAF, bytes)
+	img.set_data(width, height, false, Image.FORMAT_RGBAF, bytes)
+	return img
 
 ## Reuse an ImageTexture when the image size is unchanged; reallocate on resize.
 ## ImageTexture.get_size() is Vector2 while Image.get_size() is Vector2i, so compare

--- a/addons/lit/shaders/lit_receiver.gdshader
+++ b/addons/lit/shaders/lit_receiver.gdshader
@@ -63,12 +63,13 @@ uniform float directional_shadow_reach = 1.0;
 // of k * d / t for the penumbra. Returns 1 fully lit, 0 occluded. max_steps lets the
 // caller spend fewer iterations on short marches; the loop bound stays constant so it
 // can unroll.
-float lit_shadow(vec2 frag_sdf, vec2 light_sdf, float hardness, int max_steps) {
+float lit_shadow(vec2 frag_sdf, vec2 light_sdf, float hardness, int max_steps, bool frag_in_occluder) {
 	// Screen-space SDF has no notion of 2D draw order. A fragment sitting inside
 	// an occluder's footprint is treated as on top of it, so a sprite drawn over
 	// an occluder stays lit instead of self-shadowing. (Distinct occluders that
-	// lie between this fragment and the light still cast normally.)
-	if (texture_sdf(frag_sdf) <= 0.0) {
+	// lie between this fragment and the light still cast normally.) The sample is
+	// fragment-constant, so the caller passes it in.
+	if (frag_in_occluder) {
 		return 1.0;
 	}
 	vec2 delta = light_sdf - frag_sdf;
@@ -98,7 +99,7 @@ float lit_shadow(vec2 frag_sdf, vec2 light_sdf, float hardness, int max_steps) {
 // subtractive light). Called once per light affecting the fragment, from the directional
 // sweep and the per-tile loop in fragment().
 vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
-		vec2 frag_uv, vec2 frag_sdf, float sdf_diag) {
+		vec2 frag_uv, vec2 frag_sdf, float sdf_diag, bool frag_in_occluder) {
 	// Texel 0 carries the cheap fields (type | flags | mask | falloff) so masked-out
 	// lights bail after a single fetch, before any position/color/shadow texels.
 	vec4 t0 = texelFetch(lit_light_data, ivec2(0, i), 0);
@@ -148,7 +149,9 @@ vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
 			return vec3(0.0);                // beyond range
 		}
 		Ldir = normalize(vec3(to_light_px, height));
-		atten = pow(clamp(1.0 - dist / range, 0.0, 1.0), falloff);
+		// falloff is the attenuation-curve exponent; 1.0 is linear, so skip the pow.
+		float falloff_base = clamp(1.0 - dist / range, 0.0, 1.0);
+		atten = (falloff == 1.0) ? falloff_base : pow(falloff_base, falloff);
 
 		// A spot is a point light masked to a cone (texel 4): aim.xy is the
 		// screen-space direction it points. The fragment is lit if it falls inside
@@ -215,7 +218,7 @@ vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
 			steps = clamp(steps, 16, lit_shadow_steps_max);
 		}
 
-		float s = lit_shadow(frag_sdf, light_sdf, t3.w, steps);
+		float s = lit_shadow(frag_sdf, light_sdf, t3.w, steps, frag_in_occluder);
 		contribution *= mix(t3.rgb, vec3(1.0), s);
 	}
 
@@ -237,6 +240,10 @@ void fragment() {
 	vec2 frag_uv = SCREEN_UV;                     // canonical screen-UV space
 	vec2 frag_sdf = screen_uv_to_sdf(SCREEN_UV);  // shadow-march space
 
+	// Self-shadow guard (see lit_shadow): a fragment inside an occluder's own footprint
+	// stays lit. Fragment-constant, so sampled once here.
+	bool frag_in_occluder = texture_sdf(frag_sdf) <= 0.0;
+
 	// Screen diagonal in SDF units: the natural scale for a directional shadow's march
 	// distance, keeping the step budget well-sampled at any resolution.
 	float sdf_diag = length(screen_uv_to_sdf(vec2(1.0)) - screen_uv_to_sdf(vec2(0.0)));
@@ -249,7 +256,7 @@ void fragment() {
 		// Directional lights cover the whole screen, so they're never tiled: shade the
 		// leading directional rows for every fragment.
 		for (int i = 0; i < lit_directional_count; i++) {
-			lit += lit_shade(i, albedo, N, spec_shin, shininess, frag_uv, frag_sdf, sdf_diag);
+			lit += lit_shade(i, albedo, N, spec_shin, shininess, frag_uv, frag_sdf, sdf_diag, frag_in_occluder);
 		}
 
 		// Positional lights: look up this fragment's tile and shade only the lights
@@ -263,12 +270,12 @@ void fragment() {
 			int flat_idx = offset + j;
 			ivec2 icoord = ivec2(flat_idx % LIT_INDEX_TEX_WIDTH, flat_idx / LIT_INDEX_TEX_WIDTH);
 			int li = int(round(texelFetch(lit_tile_indices, icoord, 0).x));
-			lit += lit_shade(li, albedo, N, spec_shin, shininess, frag_uv, frag_sdf, sdf_diag);
+			lit += lit_shade(li, albedo, N, spec_shin, shininess, frag_uv, frag_sdf, sdf_diag, frag_in_occluder);
 		}
 	} else {
 		// Fallback: no tile grid published, so iterate every light.
 		for (int i = 0; i < lit_light_count; i++) {
-			lit += lit_shade(i, albedo, N, spec_shin, shininess, frag_uv, frag_sdf, sdf_diag);
+			lit += lit_shade(i, albedo, N, spec_shin, shininess, frag_uv, frag_sdf, sdf_diag, frag_in_occluder);
 		}
 	}
 


### PR DESCRIPTION
# Core Engine Performance Changes

Performance-only pass on the core lighting/shadow engine. No feature or fidelity changes.

**Shader - `addons/lit/shaders/lit_receiver.gdshader`**

- **Hoisted self-shadow SDF sample.** `texture_sdf(frag_sdf)` was sampled once per shadow-casting light; it's fragment-constant, so it's now sampled once in `fragment()` as `frag_in_occluder` and passed into `lit_shade` → `lit_shadow`. N shadow-casters → 1 SDF fetch instead of N.
- **`pow` fast path for attenuation.** `falloff == 1.0` (the default) now uses the linear term directly and skips the `pow` intrinsic.

**Registry - `addons/lit/runtime/lit_light_registry.gd`**

- **Rewrote `_build_tiles` as a counting sort.** Tally per-tile counts → prefix-sum to offsets → scatter light rows. Removed all per-tile `PackedInt32Array` allocations.
- **Eliminated `Image.set_pixel` loops.** Header and index data now written into reused float buffers and uploaded via `create_from_data`/`set_data` (new `_image_from_floats` helper), mirroring the existing pack-buffer path.
- **Reused buffers/images across frames.** Added persistent `_tile_header_img`, `_tile_index_img`, `_tile_header_buf`, `_tile_index_buf`, `_tile_counts`, `_tile_offsets`, `_tile_spans` — no per-frame `Image` reallocation steady-state.

**Bug fix (introduced during the rewrite)**

- **`max()` → `maxi()`** for `tiles_x`/`tiles_y` in `_build_tiles` (and `_publish_empty_tiles`). `max()` returns Variant and broke `:=` type inference, causing editor parse errors and cascade failures in `lit_manager.gd` / `lit_plugin.gd`.