### PR TITLE
Bphong

### DIFF
--- a/Test/Test.tscn
+++ b/Test/Test.tscn
@@ -54,6 +54,7 @@ shader_parameter/emissive_strength = 0.0
 shader_parameter/receiver_mask = 1
 shader_parameter/specular_strength = 0.5
 shader_parameter/specular_k = 32.0
+shader_parameter/has_specular_map = true
 shader_parameter/metallic_value = 0.0
 shader_parameter/roughness_value = 1.0
 shader_parameter/ao_map = ExtResource("3_x1o0v")

--- a/addons/lit/lit_plugin.gd
+++ b/addons/lit/lit_plugin.gd
@@ -251,7 +251,7 @@ func _unpersist_globals() -> void:
 func _project_setting_defs() -> Array:
 	return [
 		{
-			# 0 = Blinn-Phong (ambient + Lambert + sharpened-N.L specular), 1 = PBR
+			# 0 = Blinn-Phong (ambient + Lambert + half-vector specular), 1 = PBR
 			# (metallic-roughness Cook-Torrance). Must match LIT_MODEL_* in the receiver
 			# shader and LitManager.LightingModel.
 			#

--- a/addons/lit/nodes/lit_sprite_2d.gd
+++ b/addons/lit/nodes/lit_sprite_2d.gd
@@ -36,6 +36,11 @@ const RECEIVER_SHADER_PATH := "res://addons/lit/shaders/lit_receiver.gdshader"
 		_set_param("receiver_mask", value)
 
 
+# The CanvasTexture currently watched for specular-slot changes, so we can re-evaluate
+# has_specular_map live when the user assigns or clears a specular map in the inspector.
+var _watched_texture: CanvasTexture = null
+
+
 func _init() -> void:
 	# Pre-wire on creation without clobbering anything a saved scene or a user already
 	# assigned. The scene deserializer sets these after _init, overriding the defaults
@@ -49,6 +54,33 @@ func _init() -> void:
 	# Push the initial proxy values onto the freshly-made material.
 	_set_param("emissive_strength", emissive_strength)
 	_set_param("receiver_mask", receiver_mask)
+
+
+func _ready() -> void:
+	# Keep has_specular_map in sync so the Blinn-Phong path picks the half-vector specular
+	# only when a specular map is actually present (it blows out without one). texture_changed
+	# fires on texture swaps; we also subscribe to the CanvasTexture itself so assigning the
+	# specular map in the inspector updates live. Connect first, then evaluate once for the
+	# texture the scene deserializer already set.
+	if not texture_changed.is_connected(_on_texture_changed):
+		texture_changed.connect(_on_texture_changed)
+	_on_texture_changed()
+
+
+# Re-point the specular-slot subscription at the current CanvasTexture, then refresh the flag.
+func _on_texture_changed() -> void:
+	if _watched_texture != null and is_instance_valid(_watched_texture):
+		if _watched_texture.changed.is_connected(_update_specular_flag):
+			_watched_texture.changed.disconnect(_update_specular_flag)
+	_watched_texture = texture as CanvasTexture
+	if _watched_texture != null and not _watched_texture.changed.is_connected(_update_specular_flag):
+		_watched_texture.changed.connect(_update_specular_flag)
+	_update_specular_flag()
+
+
+func _update_specular_flag() -> void:
+	var present := _watched_texture != null and _watched_texture.specular_texture != null
+	_set_param("has_specular_map", present)
 
 
 func _set_param(param: String, value: Variant) -> void:

--- a/addons/lit/shaders/lit_receiver.gdshader
+++ b/addons/lit/shaders/lit_receiver.gdshader
@@ -61,6 +61,15 @@ uniform int receiver_mask = 1;
 uniform float specular_strength = 0.5;
 uniform float specular_k = 32.0;
 
+// Per-instance: is a specular map actually present on this receiver? LitSprite2D
+// auto-detects it from the CanvasTexture's specular slot; other receiver types can set it
+// by hand. Godot reports the same SPECULAR_SHININESS for "no map" and "white map", so the
+// shader can't tell on its own. When true the Blinn-Phong path uses the true half-vector
+// specular (crisp, view-aware, shaped by the map). When false it falls back to the
+// original sharpened-N.L lobe, which stays well-behaved on flat, un-normal-mapped surfaces
+// where the half-vector would otherwise blow the highlight out. PBR mode ignores this.
+uniform bool has_specular_map = false;
+
 // --- PBR (metallic-roughness) material inputs ---------------------------------------
 // Sampled only when lit_lighting_model == LIT_MODEL_PBR. Each map multiplies its scalar,
 // and the maps default to white so an unassigned map falls back to the scalar alone:
@@ -261,19 +270,30 @@ vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
 	} else {
 		vec3 diffuse = albedo * light_color * energy * ndotl * atten;
 
-		// True (2.5D) Blinn-Phong specular: the half-vector between the light and the view.
-		// Same fixed orthographic view as the PBR path (the eye looks down +Z at the
-		// canvas, so V points toward the viewer), so the highlight sits where the surface
-		// reflects the light toward the eye rather than merely where it faces the light.
-		// Gated by ndotl so the lobe never appears on the side facing away from the light.
-		// Tinted by light_color so the highlight takes the light's hue instead of blowing
-		// out to white. Skipped entirely when there's no specular map or strength.
+		// Highlight tinted by light_color so it takes the light's hue instead of blowing
+		// out to white. Gated by ndotl so it never appears on the side facing away from
+		// the light, and skipped entirely when there's no specular strength or color.
 		vec3 specular = vec3(0.0);
 		if (specular_strength > 0.0 && ndotl > 0.0 && dot(spec_shin, spec_shin) > 0.0) {
-			vec3 V = vec3(0.0, 0.0, 1.0);
-			vec3 H = normalize(Ldir + V);
-			float n_dot_h = max(dot(N, H), 0.0);
-			specular = light_color * spec_shin * energy * atten * pow(n_dot_h, 1.0 + shininess * specular_k) * specular_strength;
+			float exponent = 1.0 + shininess * specular_k;
+			float lobe;
+			if (has_specular_map) {
+				// True (2.5D) Blinn-Phong: the half-vector between light and view. Same
+				// fixed orthographic view as the PBR path (the eye looks down +Z, so V
+				// points toward the viewer), so the highlight sits where the surface
+				// reflects the light toward the eye. A specular map shapes/masks it, which
+				// keeps it from blowing out on flat areas.
+				vec3 V = vec3(0.0, 0.0, 1.0);
+				vec3 H = normalize(Ldir + V);
+				lobe = pow(max(dot(N, H), 0.0), exponent);
+			} else {
+				// No specular map to shape the half-vector lobe, which would otherwise read
+				// as a flat blown-out wash on un-normal-mapped surfaces (H biases toward N).
+				// Fall back to the sharpened N.L lobe, which behaves with or without a
+				// normal map.
+				lobe = pow(ndotl, exponent);
+			}
+			specular = light_color * spec_shin * energy * atten * lobe * specular_strength;
 		}
 
 		contribution = diffuse + specular;

--- a/addons/lit/shaders/lit_receiver.gdshader
+++ b/addons/lit/shaders/lit_receiver.gdshader
@@ -13,11 +13,11 @@ global uniform vec4      lit_ambient_color : source_color;
 global uniform float     lit_ambient_energy;
 
 // Lighting model selector, published by the manager (and the editor plugin) from the
-// lit/render/lighting_model project setting. 0 = Phong-style (the original ambient +
-// Lambert + sharpened-N.L specular), 1 = PBR (metallic-roughness Cook-Torrance). The
-// branch is on a global uniform, so every receiver honors the toggle live and all
-// fragments take the same path (coherent, cheap). When Phong is selected the PBR-only
-// material inputs are never sampled, so it costs nothing.
+// lit/render/lighting_model project setting. 0 = Blinn-Phong (ambient + Lambert +
+// half-vector specular), 1 = PBR (metallic-roughness Cook-Torrance). The branch is on a
+// global uniform, so every receiver honors the toggle live and all fragments take the
+// same path (coherent, cheap). When Blinn-Phong is selected the PBR-only material inputs
+// are never sampled, so it costs nothing.
 global uniform int       lit_lighting_model;
 
 // Tiled light culling: the manager bins each positional light into a screen-tile grid
@@ -56,7 +56,8 @@ uniform sampler2D emissive_mask : hint_default_white;   // white default lets st
 // 2D-render-layers control.
 uniform int receiver_mask = 1;
 
-// Phong specular controls (LIT_MODEL_PHONG only). Ignored in PBR mode.
+// Blinn-Phong specular controls (LIT_MODEL_PHONG only). Ignored in PBR mode.
+// specular_k scales how the CanvasTexture shininess maps to the half-vector exponent.
 uniform float specular_strength = 0.5;
 uniform float specular_k = 32.0;
 
@@ -260,12 +261,19 @@ vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
 	} else {
 		vec3 diffuse = albedo * light_color * energy * ndotl * atten;
 
-		// Sharpened N.L lobe, tight and only where the surface tilts toward the light.
+		// True (2.5D) Blinn-Phong specular: the half-vector between the light and the view.
+		// Same fixed orthographic view as the PBR path (the eye looks down +Z at the
+		// canvas, so V points toward the viewer), so the highlight sits where the surface
+		// reflects the light toward the eye rather than merely where it faces the light.
+		// Gated by ndotl so the lobe never appears on the side facing away from the light.
 		// Tinted by light_color so the highlight takes the light's hue instead of blowing
 		// out to white. Skipped entirely when there's no specular map or strength.
 		vec3 specular = vec3(0.0);
-		if (specular_strength > 0.0 && dot(spec_shin, spec_shin) > 0.0) {
-			specular = light_color * spec_shin * energy * atten * pow(ndotl, 1.0 + shininess * specular_k) * specular_strength;
+		if (specular_strength > 0.0 && ndotl > 0.0 && dot(spec_shin, spec_shin) > 0.0) {
+			vec3 V = vec3(0.0, 0.0, 1.0);
+			vec3 H = normalize(Ldir + V);
+			float n_dot_h = max(dot(N, H), 0.0);
+			specular = light_color * spec_shin * energy * atten * pow(n_dot_h, 1.0 + shininess * specular_k) * specular_strength;
 		}
 
 		contribution = diffuse + specular;

--- a/project.godot
+++ b/project.godot
@@ -31,6 +31,10 @@ window/stretch/aspect="expand"
 
 enabled=PackedStringArray("res://addons/lit/plugin.cfg")
 
+[lit]
+
+render/lighting_model=1
+
 [physics]
 
 3d/physics_engine="Jolt Physics"

--- a/project.godot
+++ b/project.godot
@@ -31,10 +31,6 @@ window/stretch/aspect="expand"
 
 enabled=PackedStringArray("res://addons/lit/plugin.cfg")
 
-[lit]
-
-render/lighting_model=1
-
 [physics]
 
 3d/physics_engine="Jolt Physics"


### PR DESCRIPTION
bphong updates. Makes the engines bphong a proper and full implementation while keeping specular overloading to a minimum when no specular map is present.