### PR TITLE
Add Self Shadow toggle to LitSprite2D

### DIFF
--- a/Test/Test.tscn
+++ b/Test/Test.tscn
@@ -53,6 +53,8 @@ emission_curve = SubResource("CurveTexture_abemx")
 shader = ExtResource("3_es8hm")
 shader_parameter/emissive_strength = 0.0
 shader_parameter/receiver_mask = 1
+shader_parameter/self_shadow = false
+shader_parameter/self_rect = Vector4(-16, -16, 16, 16)
 shader_parameter/specular_strength = 0.5
 shader_parameter/specular_k = 32.0
 shader_parameter/has_specular_map = true
@@ -70,8 +72,8 @@ diffuse_texture = ExtResource("1_n8bxl")
 normal_texture = ExtResource("2_pyd3v")
 specular_texture = ExtResource("6_abemx")
 
-[sub_resource type="OccluderPolygon2D" id="OccluderPolygon2D_ywxc3"]
-polygon = PackedVector2Array(-5.200012, -11.799999, -9.400017, -7.5999985, -9.600014, 1.5999947, -7.8000107, 7.200001, -3.0000153, 13.200001, 2.1999893, 12.999996, 6.599991, 7.999996, 8.399994, 1.5999947, 8.999992, -6.4000053, 6.799988, -10.600006, 2.399994, -12.000008)
+[sub_resource type="OccluderPolygon2D" id="OccluderPolygon2D_ynfqq"]
+polygon = PackedVector2Array(-7.199997, 5.5999985, 6.2000046, 5.5999985, 2.600006, 12.799995, -3.7999954, 12.799995)
 
 [node name="Test" type="Node2D" unique_id=1250791965]
 
@@ -88,6 +90,7 @@ lifetime = 2.0
 process_material = SubResource("ParticleProcessMaterial_ynfqq")
 
 [node name="LitSprite2D" type="Sprite2D" parent="." unique_id=1127649428]
+z_index = 1
 material = SubResource("ShaderMaterial_s7aw1")
 position = Vector2(586, 320.00003)
 scale = Vector2(5, 5)
@@ -95,11 +98,9 @@ texture = SubResource("CanvasTexture_x1o0v")
 script = ExtResource("6_ngwpp")
 metadata/_custom_type_script = "uid://drrhypxeb6nsg"
 
-[node name="LightOccluder2D" type="LightOccluder2D" parent="LitSprite2D" unique_id=1876398662]
+[node name="LightOccluder2D2" type="LightOccluder2D" parent="LitSprite2D" unique_id=204842395]
 z_index = -1
-position = Vector2(1.5258789e-05, -0.3999977)
-scale = Vector2(0.99999994, 0.99999994)
-occluder = SubResource("OccluderPolygon2D_ywxc3")
+occluder = SubResource("OccluderPolygon2D_ynfqq")
 
 [node name="LitCanvasModulate" type="Node2D" parent="." unique_id=1199514877]
 script = ExtResource("3_4l8u5")
@@ -120,7 +121,7 @@ shadow_hardness = 0.0
 metadata/_custom_type_script = "uid://7156lwdhmrod"
 
 [node name="LitPointLight2D" type="Node2D" parent="LitLights" unique_id=2029040104]
-position = Vector2(574, 122)
+position = Vector2(582, 161)
 script = ExtResource("4_lg8mm")
 color = Color(1, 0.5137255, 0, 1)
 range = 1024.0

--- a/Test/tilesets/crypts/tile_basic_crypt.tscn
+++ b/Test/tilesets/crypts/tile_basic_crypt.tscn
@@ -1,8 +1,8 @@
 [gd_scene format=3 uid="uid://d28fv3x2iqnq2"]
 
 [ext_resource type="Shader" uid="uid://ck1hue5r77ak" path="res://addons/lit/shaders/lit_receiver.gdshader" id="1_b50dt"]
-[ext_resource type="Texture2D" uid="uid://b5dynsun8hih6" path="res://Test/tilesets/crypts/ra_crypt/ra_crypt.png" id="2_pulpr"]
-[ext_resource type="Texture2D" uid="uid://cpxht66cg16wx" path="res://Test/tilesets/crypts/ra_crypt/ra_crypt_n.png" id="4_rcxug"]
+[ext_resource type="Texture2D" uid="uid://bcoyinyc7nquk" path="res://Test/tilesets/crypts/ra_crypt/ra_crypt.png" id="2_pulpr"]
+[ext_resource type="Texture2D" uid="uid://c3cltubry87tc" path="res://Test/tilesets/crypts/ra_crypt/ra_crypt_n.png" id="4_rcxug"]
 [ext_resource type="Script" uid="uid://c4ukaxjuidwha" path="res://Test/tilesets/game_tile.gd" id="5_vvk8t"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_gg4cr"]

--- a/addons/lit/README.md
+++ b/addons/lit/README.md
@@ -40,7 +40,9 @@ Prefer videos? Subscribe on YouTube:
    color, energy, and range to taste.
 5. **Want shadows?** On the light, tick **Shadow Enabled**. Then give the world something to
    block the light: add a `LightOccluder2D` to a sprite, or for tiles enable **SDF
-   Collision** on your TileSet's occlusion layer.
+   Collision** on your TileSet's occlusion layer. A `LitSprite2D` never shadows itself —
+   its occluder's shadow falls behind it (flip **Self Shadow** on the sprite if you want
+   plain SDF shadowing back).
 6. **Want a look?** Add a **`LitPostProcess`** node and switch on bloom, color grade, CRT,
    or any of the other effects.
 
@@ -53,6 +55,8 @@ That's it — everything updates live in the editor as you build.
 - **Uncapped lights & Shadows.** No 15-light limit. Use as many as your scene needs.
 - **Three light types.** Point, Directional (a sun), and Spot (a cone).
 - **Soft or hard shadows.** One slider per light, from razor-sharp to feathery.
+- **No self-shadowing.** A sprite's own occluder casts behind it, not onto it, so you
+  don't have to trace silhouette-perfect polygons. Per-sprite **Self Shadow** toggle.
 - **Normal maps & specular, free.** Reads them straight from your `CanvasTexture` — no wiring.
 - **Blinn–Phong or PBR.** Pick the lighting model in Project Settings → Lit. PBR adds
   optional metallic / roughness / AO inputs on the receiver material; switch back to

--- a/addons/lit/nodes/lit_sprite_2d.gd
+++ b/addons/lit/nodes/lit_sprite_2d.gd
@@ -35,6 +35,14 @@ const RECEIVER_SHADER_PATH := "res://addons/lit/shaders/lit_receiver.gdshader"
 		receiver_mask = value
 		_set_param("receiver_mask", value)
 
+## Self-shadowing: when off (the default), occluders inside this sprite's own rect can't
+## cast onto it — its shadow renders behind it. Occluders outside the rect still shadow
+## it normally. Proxies to `self_shadow`.
+@export var self_shadow: bool = false:
+	set(value):
+		self_shadow = value
+		_set_param("self_shadow", value)
+
 
 # The CanvasTexture currently watched for specular-slot changes, so we can re-evaluate
 # has_specular_map live when the user assigns or clears a specular map in the inspector.
@@ -54,6 +62,7 @@ func _init() -> void:
 	# Push the initial proxy values onto the freshly-made material.
 	_set_param("emissive_strength", emissive_strength)
 	_set_param("receiver_mask", receiver_mask)
+	_set_param("self_shadow", self_shadow)
 
 
 func _ready() -> void:
@@ -65,6 +74,12 @@ func _ready() -> void:
 	if not texture_changed.is_connected(_on_texture_changed):
 		texture_changed.connect(_on_texture_changed)
 	_on_texture_changed()
+
+	# Keep the shader's self-shadow rect synced (item_rect_changed covers texture,
+	# centered, offset, region, and frames).
+	if not item_rect_changed.is_connected(_update_self_rect):
+		item_rect_changed.connect(_update_self_rect)
+	_update_self_rect()
 
 
 # Re-point the specular-slot subscription at the current CanvasTexture, then refresh the flag.
@@ -81,6 +96,12 @@ func _on_texture_changed() -> void:
 func _update_specular_flag() -> void:
 	var present := _watched_texture != null and _watched_texture.specular_texture != null
 	_set_param("has_specular_map", present)
+
+
+# Push the local rect as min.xy | max.xy; the shader treats an empty rect as off.
+func _update_self_rect() -> void:
+	var r := get_rect()
+	_set_param("self_rect", Vector4(r.position.x, r.position.y, r.end.x, r.end.y))
 
 
 func _set_param(param: String, value: Variant) -> void:

--- a/addons/lit/plugin.cfg
+++ b/addons/lit/plugin.cfg
@@ -3,5 +3,5 @@
 name="Lit"
 description="Drop-in 2D lighting for Godot 4 — with no light limit."
 author="Fading Lantern Games"
-version="1.0.3"
+version="1.0.4"
 script="lit_plugin.gd"

--- a/addons/lit/shaders/lit_receiver.gdshader
+++ b/addons/lit/shaders/lit_receiver.gdshader
@@ -56,6 +56,12 @@ uniform sampler2D emissive_mask : hint_default_white;   // white default lets st
 // 2D-render-layers control.
 uniform int receiver_mask = 1;
 
+// Self-shadow exclusion: when self_shadow is off, shadow-march hits inside self_rect
+// (this item's local rect) are ignored, so a sprite's own occluder casts behind it, not
+// onto it. LitSprite2D syncs self_rect; the empty default disables the test entirely.
+uniform bool self_shadow = false;
+uniform vec4 self_rect = vec4(0.0);  // local-space min.xy | max.xy; empty = off
+
 // Blinn-Phong specular controls (LIT_MODEL_PHONG only). Ignored in PBR mode.
 // specular_k scales how the CanvasTexture shininess maps to the half-vector exponent.
 uniform float specular_strength = 0.5;
@@ -98,12 +104,27 @@ uniform float directional_horizontal_scale = 32.0;
 // well-sampled; a fixed huge distance would under-sample the penumbra.
 uniform float directional_shadow_reach = 1.0;
 
+// Fragment position in the item's local space, for the self-shadow rect test.
+varying vec2 v_local;
+
+void vertex() {
+	v_local = VERTEX;
+}
+
+// True when a local-space march sample falls inside this item's own rect.
+bool lit_in_self(vec2 p_local) {
+	return p_local.x >= self_rect.x && p_local.y >= self_rect.y
+			&& p_local.x <= self_rect.z && p_local.y <= self_rect.w;
+}
+
 // Soft-shadow march of Godot's screen-space SDF (the IQ technique). Works in SDF
 // space, marching from the fragment toward the light and tracking the running minimum
 // of k * d / t for the penumbra. Returns 1 fully lit, 0 occluded. max_steps lets the
 // caller spend fewer iterations on short marches; the loop bound stays constant so it
-// can unroll.
-float lit_shadow(vec2 frag_sdf, vec2 light_sdf, float hardness, int max_steps) {
+// can unroll. When self_ex is true, hits inside the receiver's own rect (mapped via
+// self_local + sdf_to_local) are stepped through instead of occluding.
+float lit_shadow(vec2 frag_sdf, vec2 light_sdf, float hardness, int max_steps,
+		bool self_ex, vec2 self_local, mat2 sdf_to_local) {
 	// Screen-space SDF has no notion of 2D draw order. A fragment sitting inside
 	// an occluder's footprint is treated as on top of it, so a sprite drawn over
 	// an occluder stays lit instead of self-shadowing. (Distinct occluders that
@@ -124,11 +145,24 @@ float lit_shadow(vec2 frag_sdf, vec2 light_sdf, float hardness, int max_steps) {
 		if (s >= max_steps || t >= maxd) {
 			break;
 		}
-		float d = texture_sdf(frag_sdf + dir * t);
-		if (d < 0.001) {
-			return 0.0;                      // fully occluded
+		vec2 offset = dir * t;
+		float d = texture_sdf(frag_sdf + offset);
+		float cand = k * d / t;
+		// Test self-exclusion only when the sample matters (hit or lower penumbra).
+		if (d < 0.001 || cand < res) {
+			if (self_ex && lit_in_self(self_local + sdf_to_local * offset)) {
+				if (d < 0.001) {
+					// Cross the excluded occluder: -d is the distance to its far edge.
+					t += max(-d, shadow_min_step);
+					continue;
+				}
+			} else {
+				if (d < 0.001) {
+					return 0.0;              // fully occluded
+				}
+				res = cand;                  // penumbra accumulation
+			}
 		}
-		res = min(res, k * d / t);           // penumbra accumulation
 		t += max(d, shadow_min_step);
 	}
 	return clamp(res, 0.0, 1.0);
@@ -163,7 +197,8 @@ vec3 lit_f_schlick(float v_dot_h, vec3 f0) {
 // fragment by the caller and used only in PBR mode.
 vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
 		float metallic, float roughness,
-		vec2 frag_uv, vec2 frag_sdf, float sdf_diag) {
+		vec2 frag_uv, vec2 frag_sdf, float sdf_diag,
+		bool self_ex, vec2 self_local, mat2 sdf_to_local) {
 	// Texel 0 carries the cheap fields (type | flags | mask | falloff) so masked-out
 	// lights bail after a single fetch, before any position/color/shadow texels.
 	vec4 t0 = texelFetch(lit_light_data, ivec2(0, i), 0);
@@ -333,7 +368,7 @@ vec3 lit_shade(int i, vec3 albedo, vec3 N, vec3 spec_shin, float shininess,
 			steps = clamp(steps, 16, lit_shadow_steps_max);
 		}
 
-		float s = lit_shadow(frag_sdf, light_sdf, t3.w, steps);
+		float s = lit_shadow(frag_sdf, light_sdf, t3.w, steps, self_ex, self_local, sdf_to_local);
 		contribution *= mix(t3.rgb, vec3(1.0), s);
 	}
 
@@ -371,6 +406,20 @@ void fragment() {
 	// distance, keeping the step budget well-sampled at any resolution.
 	float sdf_diag = length(screen_uv_to_sdf(vec2(1.0)) - screen_uv_to_sdf(vec2(0.0)));
 
+	// Self-shadow basis: map SDF-space march offsets to local space. Both spaces are
+	// affine images of the screen, so probing one pixel step in each and composing is
+	// exact. The uniform condition keeps the derivative calls in uniform control flow.
+	bool self_ex = !self_shadow && self_rect.z > self_rect.x && self_rect.w > self_rect.y;
+	mat2 sdf_to_local = mat2(vec2(0.0), vec2(0.0));
+	if (self_ex) {
+		// Columns: per-pixel-step delta of each space, in x and y.
+		mat2 px_to_sdf = mat2(
+				screen_uv_to_sdf(SCREEN_UV + vec2(SCREEN_PIXEL_SIZE.x, 0.0)) - frag_sdf,
+				screen_uv_to_sdf(SCREEN_UV + vec2(0.0, SCREEN_PIXEL_SIZE.y)) - frag_sdf);
+		mat2 px_to_local = mat2(dFdx(v_local), dFdy(v_local));
+		sdf_to_local = px_to_local * inverse(px_to_sdf);
+	}
+
 	// Tiling is only used once the manager has published a grid; until then (and in the
 	// zero-light case) fall back to looping every light.
 	bool tiling_valid = lit_tile_grid.x > 0 && lit_tile_grid.y > 0 && lit_tile_size > 0;
@@ -379,7 +428,7 @@ void fragment() {
 		// Directional lights cover the whole screen, so they're never tiled: shade the
 		// leading directional rows for every fragment.
 		for (int i = 0; i < lit_directional_count; i++) {
-			lit += lit_shade(i, albedo, N, spec_shin, shininess, metallic, roughness, frag_uv, frag_sdf, sdf_diag);
+			lit += lit_shade(i, albedo, N, spec_shin, shininess, metallic, roughness, frag_uv, frag_sdf, sdf_diag, self_ex, v_local, sdf_to_local);
 		}
 
 		// Positional lights: look up this fragment's tile and shade only the lights
@@ -393,12 +442,12 @@ void fragment() {
 			int flat_idx = offset + j;
 			ivec2 icoord = ivec2(flat_idx % LIT_INDEX_TEX_WIDTH, flat_idx / LIT_INDEX_TEX_WIDTH);
 			int li = int(round(texelFetch(lit_tile_indices, icoord, 0).x));
-			lit += lit_shade(li, albedo, N, spec_shin, shininess, metallic, roughness, frag_uv, frag_sdf, sdf_diag);
+			lit += lit_shade(li, albedo, N, spec_shin, shininess, metallic, roughness, frag_uv, frag_sdf, sdf_diag, self_ex, v_local, sdf_to_local);
 		}
 	} else {
 		// Fallback: no tile grid published, so iterate every light.
 		for (int i = 0; i < lit_light_count; i++) {
-			lit += lit_shade(i, albedo, N, spec_shin, shininess, metallic, roughness, frag_uv, frag_sdf, sdf_diag);
+			lit += lit_shade(i, albedo, N, spec_shin, shininess, metallic, roughness, frag_uv, frag_sdf, sdf_diag, self_ex, v_local, sdf_to_local);
 		}
 	}
 


### PR DESCRIPTION
This PR stops sprites from casting shadows onto themselves. Shadow-march hits that land inside a receiver's own rect are now ignored, so a sprite's own occluder casts its shadow behind the sprite instead of across it, while occluders outside the rect still shadow it normally. This is on by default for LitSprite2D nodes and can be reverted per sprite with the new Self Shadow toggle.