### PR TITLE
Shader Precompile Config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ docs/plans/
 # OS-specific
 .DS_Store
 Thumbs.db
+
+# Lit Specific
+lit_precompile.cfg

--- a/Test/nodes/skele_3.tscn
+++ b/Test/nodes/skele_3.tscn
@@ -22,7 +22,6 @@ shader_parameter/shadow_steps = 64
 shader_parameter/shadow_min_step = 0.2
 shader_parameter/footprint_shadow = 16.0
 shader_parameter/directional_horizontal_scale = 32.0
-shader_parameter/directional_shadow_reach = 1.0
 
 [sub_resource type="CanvasTexture" id="CanvasTexture_ywxc3"]
 diffuse_texture = ExtResource("2_8w312")

--- a/addons/lit/README.md
+++ b/addons/lit/README.md
@@ -177,7 +177,9 @@ if LitManager.precompile_shaders():          # false if one is already running
 	await LitManager.precompile_finished
 ```
 
-The `lit/startup/*` settings: `precompile_shaders` (the launch-time build on/off),
-`precompile_async` (worker-backed background mode), `precompile_title` (custom screen
-title), `precompile_verbose` (show the shader being compiled), and
-`precompile_async_position` (where the floating progress box sits).
+**Precompile only what you use.** **Project → Tools → Generate Lit Precompile
+Config** scans your scenes for actual Lit usage and writes the exact shader list to
+`res://lit_precompile.cfg`. While that file exists, only what it names is built;
+delete it to build everything again. Exports pack the file automatically. Regenerate
+when your Lit usage changes - usage created purely from code is invisible to the
+scan, and debug builds warn when a shader compiles outside the list.

--- a/addons/lit/editor/lit_export_plugin.gd
+++ b/addons/lit/editor/lit_export_plugin.gd
@@ -1,0 +1,18 @@
+@tool
+extends EditorExportPlugin
+
+## Packs res://lit_precompile.cfg into every export when it exists: a loose .cfg is
+## not a resource, so the exporter would otherwise strip it and shipped games would
+## silently fall back to the full precompile.
+
+const LitShaderPrecompilerScript := preload("res://addons/lit/runtime/lit_shader_precompiler.gd")
+
+
+func _get_name() -> String:
+	return "LitPrecompileConfig"
+
+
+func _export_begin(_features: PackedStringArray, _is_debug: bool, _path: String, _flags: int) -> void:
+	var cfg_path: String = LitShaderPrecompilerScript.CONFIG_PATH
+	if FileAccess.file_exists(cfg_path):
+		add_file(cfg_path, FileAccess.get_file_as_bytes(cfg_path), false)

--- a/addons/lit/editor/lit_export_plugin.gd.uid
+++ b/addons/lit/editor/lit_export_plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://dvn6m3468qb3a

--- a/addons/lit/editor/lit_precompile_config.gd
+++ b/addons/lit/editor/lit_precompile_config.gd
@@ -1,0 +1,144 @@
+@tool
+extends RefCounted
+
+## The scan behind "Generate Lit Precompile Config" (Project > Tools): finds every
+## actual Lit use in the project's saved scenes and writes res://lit_precompile.cfg,
+## which the precompiler then runs verbatim instead of the full variant matrix
+## (delete the file to restore full builds). Scenes are read through SceneState
+## (never instanced), so no scene code runs. Lit usage created purely from code is
+## invisible here; dev builds warn when a variant compiles outside the configured
+## list, which is the cue to regenerate or hand-extend the file.
+
+const LitShaderPrecompilerScript := preload("res://addons/lit/runtime/lit_shader_precompiler.gd")
+const WorldSdfScript := preload("res://addons/lit/runtime/registry/world_sdf.gd")
+
+const LIGHT_SCRIPTS := {
+	"res://addons/lit/nodes/lit_point_light_2d.gd": true,
+	"res://addons/lit/nodes/lit_spot_light_2d.gd": true,
+	"res://addons/lit/nodes/lit_directional_light_2d.gd": true,
+}
+const RECEIVER_SCRIPTS := {
+	"res://addons/lit/nodes/lit_sprite_2d.gd": true,
+	"res://addons/lit/nodes/lit_tile_map_layer.gd": true,
+}
+
+
+## Scan, write the settings, and return a summary:
+## {scenes, variants: PackedStringArray, shaders: Array, full: int}.
+static func generate() -> Dictionary:
+	var scenes: Array[String] = []
+	LitShaderPrecompilerScript._collect_scenes("res://", scenes)
+
+	var tiers := {}
+	var receivers := false
+	var rx := false
+	var cone := false
+	var stoch := false
+	var masks := false
+	for scene_path in scenes:
+		var packed := load(scene_path) as PackedScene
+		if packed == null:
+			push_warning("Lit: precompile scan could not load '%s'; skipped" % scene_path)
+			continue
+		var state := packed.get_state()
+		for i in state.get_node_count():
+			var props := {}
+			for p in state.get_node_property_count(i):
+				props[state.get_node_property_name(i, p)] = state.get_node_property_value(i, p)
+			var script_path := ""
+			var script = props.get("script")
+			if script is Script:
+				script_path = (script as Script).resource_path
+			if RECEIVER_SCRIPTS.has(script_path):
+				receivers = true
+			# Properties are checked by name, not just by script: overrides on instanced
+			# sub-scene nodes carry the property without the script.
+			if props.has("shadow_algorithm"):
+				var algo := int(props["shadow_algorithm"])
+				cone = cone or algo == LitShaderLibrary.ShadowAlgorithm.CONE_TRACED
+				stoch = stoch or algo == LitShaderLibrary.ShadowAlgorithm.STOCHASTIC
+			elif LIGHT_SCRIPTS.has(script_path):
+				cone = true  # absent export = the CONE_TRACED default
+			if int(props.get("shadow_mask", 1)) != 1 \
+					or bool(props.get("exclude_scene_occluders", false)) \
+					or int(props.get("occluder_light_mask", 1)) != 1:
+				masks = true
+			if int(props.get("shadow_ignore_mask", 0)) != 0:
+				rx = true
+			var ts = props.get("tile_set")
+			if ts is TileSet:
+				for l in (ts as TileSet).get_occlusion_layers_count():
+					if (ts as TileSet).get_occlusion_layer_light_mask(l) != 1:
+						masks = true
+			var mat = props.get("material")
+			if mat is ShaderMaterial:
+				var flags := LitShaderLibrary.flags_of((mat as ShaderMaterial).shader)
+				if flags >= 0:
+					receivers = true
+					tiers[flags & LitShaderLibrary.TIER_MASK] = true
+
+	# Receiver tiers fluctuate at runtime (LitReceiverHelper re-tiers per frame): any
+	# receiver can sit on fast or full, and on the y-sort tier while the project
+	# setting is on. Authored material tiers are merged on top.
+	if receivers:
+		tiers[0] = true
+		tiers[LitShaderLibrary.F_SELF_EXCL] = true
+		if bool(ProjectSettings.get_setting("lit/render/y_sorting", false)):
+			tiers[LitShaderLibrary.F_SELF_EXCL | LitShaderLibrary.F_YSORT] = true
+
+	# Every subset of the observed activity axes is runtime-reachable (algorithms and
+	# masks toggle with scene state), so the powerset goes in; resolve() prunes.
+	var axes: Array[int] = []
+	if cone:
+		axes.append(LitShaderLibrary.F_CONE)
+	if stoch:
+		axes.append(LitShaderLibrary.F_STOCH)
+	if masks:
+		axes.append(LitShaderLibrary.F_MASKS)
+		axes.append(LitShaderLibrary.F_GX)
+	var node_opts: Array[int] = [0]
+	if rx:
+		node_opts.append(LitShaderLibrary.F_RX)
+	var seen := {}
+	for tier in tiers:
+		for n in node_opts:
+			for combo in 1 << axes.size():
+				var act := 0
+				for a in axes.size():
+					if combo & (1 << a) != 0:
+						act |= axes[a]
+				seen[LitShaderLibrary.resolve(tier, n, act)] = true
+	var flags_list: Array = seen.keys()
+	flags_list.sort()
+
+	var statics: Array = []
+	for tier in LitShaderLibrary.ENTRY_PATHS:
+		if tiers.has(tier):
+			statics.append(LitShaderLibrary.ENTRY_PATHS[tier])
+	if not flags_list.is_empty():
+		statics.append(WorldSdfScript.ENCODE_SHADER_PATH)
+	LitShaderPrecompilerScript._post_scan = null
+	statics.append_array(LitShaderPrecompilerScript.used_post_shaders())
+
+	var names := PackedStringArray()
+	for f in flags_list:
+		names.append(LitShaderLibrary.variant_name(f))
+	var cfg := ConfigFile.new()
+	cfg.set_value("lit", "variants", names)
+	cfg.set_value("lit", "shaders", PackedStringArray(statics))
+	var err := cfg.save(LitShaderPrecompilerScript.CONFIG_PATH)
+	if err != OK:
+		push_warning("Lit: could not write '%s' (error %d)" % [LitShaderPrecompilerScript.CONFIG_PATH, err])
+	elif Engine.is_editor_hint():
+		# The write bypasses the editor's filesystem tracking: rescan so the file
+		# shows up in the FileSystem dock, and refresh any open tab showing it
+		# (respects the user's auto-reload setting; untouched files are no-ops).
+		EditorInterface.get_resource_filesystem().scan()
+		EditorInterface.get_script_editor().reload_open_files()
+	return {
+		"scenes": scenes.size(),
+		"variants": names,
+		"shaders": statics,
+		"full": LitShaderLibrary.all_variant_flags().size(),
+		"saved": err == OK,
+	}

--- a/addons/lit/editor/lit_precompile_config.gd.uid
+++ b/addons/lit/editor/lit_precompile_config.gd.uid
@@ -1,0 +1,1 @@
+uid://blwoicd2sgnad

--- a/addons/lit/lit_plugin.gd
+++ b/addons/lit/lit_plugin.gd
@@ -19,9 +19,12 @@ const AUTOLOAD_NAME := "LitManager"
 const AUTOLOAD_PATH := "res://addons/lit/runtime/lit_manager.gd"
 
 const TOOL_MENU_ITEM := "Make Selected Nodes Lit"
+const TOOL_MENU_PRECOMPILE := "Generate Lit Precompile Config"
 
 const LitLightRegistryScript := preload("res://addons/lit/runtime/lit_light_registry.gd")
 const LitPostInspectorScript := preload("res://addons/lit/editor/lit_post_inspector.gd")
+const LitPrecompileConfigScript := preload("res://addons/lit/editor/lit_precompile_config.gd")
+const LitExportPluginScript := preload("res://addons/lit/editor/lit_export_plugin.gd")
 
 # Editor-live refresh cadence. Polling a few times a second relights the viewport when
 # a light moves, a property changes, or the 2D editor camera pans or zooms, without
@@ -34,6 +37,7 @@ var _registry: LitLightRegistry
 var _refresh_accum := 0.0
 var _warm_pending: Array[int] = []
 var _post_inspector: EditorInspectorPlugin
+var _export_plugin: EditorExportPlugin
 
 
 # --- Lifecycle ---------------------------------------------------------------
@@ -54,10 +58,14 @@ func _enter_tree() -> void:
 	_persist_project_settings() # guarded: same, for the lit/* settings
 	_ensure_autoload()          # guarded: adds only if not already registered
 	add_tool_menu_item(TOOL_MENU_ITEM, _make_selected_nodes_lit)
+	add_tool_menu_item(TOOL_MENU_PRECOMPILE, _generate_precompile_config)
 	# The "Add Effect" button on the LitPostProcess inspector.
 	_post_inspector = LitPostInspectorScript.new()
 	_post_inspector.undo_redo = get_undo_redo()
 	add_inspector_plugin(_post_inspector)
+	# Packs lit_precompile.cfg into exports (see editor/lit_export_plugin.gd).
+	_export_plugin = LitExportPluginScript.new()
+	add_export_plugin(_export_plugin)
 	# Editor-side gather driver; the autoload covers runtime but doesn't run here.
 	_registry = LitLightRegistryScript.new()
 	# Silent background warm so first-session editor tier swaps never pay a compile.
@@ -70,8 +78,11 @@ func _exit_tree() -> void:
 	_registry = null
 	LitLightRegistryScript.editor_release_live()
 	remove_tool_menu_item(TOOL_MENU_ITEM)
+	remove_tool_menu_item(TOOL_MENU_PRECOMPILE)
 	remove_inspector_plugin(_post_inspector)
 	_post_inspector = null
+	remove_export_plugin(_export_plugin)
+	_export_plugin = null
 	_remove_live_globals()
 
 func _disable_plugin() -> void:
@@ -183,6 +194,40 @@ func _make_selected_nodes_lit() -> void:
 func _start_converted_sprite(node: Node) -> void:
 	if node.has_method("_lit_ready"):
 		node.call("_lit_ready")
+
+# --- Precompile config tool ---------------------------------------------------
+#
+# "Generate Lit Precompile Config" scans the project's saved scenes for actual Lit
+# usage and writes res://lit_precompile.cfg; while that file exists, the startup
+# precompiler builds exactly that list instead of the full variant matrix. Deleting
+# the file restores the full build. The scan itself lives in
+# editor/lit_precompile_config.gd.
+
+func _generate_precompile_config() -> void:
+	var result: Dictionary = LitPrecompileConfigScript.generate()
+	if not result.saved:
+		_popup_tool_dialog("Lit Precompile Config", "Could not write res://lit_precompile.cfg; see the Output log.")
+		return
+	var variants: PackedStringArray = result.variants
+	var shaders: Array = result.shaders
+	var text: String
+	if variants.is_empty() and shaders.is_empty():
+		text = "Scanned %d scenes and found no Lit usage.\nWrote an empty res://lit_precompile.cfg, so the precompiler will build nothing.\nDelete the file to restore full builds." \
+				% result.scenes
+	else:
+		text = "Scanned %d scenes.\nPrecompile list: %d of %d receiver variants, plus %d shader files.\n\nWrote res://lit_precompile.cfg (packed into exports automatically); delete it to return to full builds.\nRegenerate after adding lights, masks, or post effects." \
+				% [result.scenes, variants.size(), result.full, shaders.size()]
+	_popup_tool_dialog("Lit Precompile Config", text)
+
+func _popup_tool_dialog(title: String, text: String) -> void:
+	var dlg := AcceptDialog.new()
+	dlg.title = title
+	dlg.dialog_text = text
+	EditorInterface.get_base_control().add_child(dlg)
+	dlg.visibility_changed.connect(func() -> void:
+		if not dlg.visible:
+			dlg.queue_free())
+	dlg.popup_centered()
 
 # --- Global shader parameter registration -------------------------------------
 #

--- a/addons/lit/runtime/lit_shader_library.gd
+++ b/addons/lit/runtime/lit_shader_library.gd
@@ -138,13 +138,20 @@ static func flags_from_path(path: String) -> int:
 	if not path.begins_with("res://addons/lit/shaders/"):
 		return -1
 	var fname := path.get_file()
-	if not fname.begins_with("lit_receiver") or not fname.ends_with(".gdshader"):
+	if not fname.ends_with(".gdshader"):
+		return -1
+	return flags_from_variant_name(fname.get_basename())
+
+
+## Inverse of variant_name; -1 for anything that isn't a canonical variant name.
+static func flags_from_variant_name(name: String) -> int:
+	if not name.begins_with("lit_receiver"):
 		return -1
 	var flags := 0
 	for axis in AXES:
 		if axis.get("absent_token", "") != "":
 			flags |= axis.flag
-	for token in fname.substr(12, fname.length() - 21).split("_", false):
+	for token in name.substr(12).split("_", false):
 		var matched := false
 		for axis in AXES:
 			if token == axis.token:

--- a/addons/lit/runtime/lit_shader_precompiler.gd
+++ b/addons/lit/runtime/lit_shader_precompiler.gd
@@ -8,6 +8,7 @@ signal progress(done: int, total: int, label: String)
 signal finished
 
 const MARKER_PATH := "user://lit_shaders.cfg"
+const CONFIG_PATH := "res://lit_precompile.cfg"
 const WORKER_DIR := "user://lit_worker"
 const WorldSdfScript := preload("res://addons/lit/runtime/registry/world_sdf.gd")
 const BUILD_BUDGET_MS := 8.0
@@ -49,10 +50,39 @@ func _init() -> void:
 ## generated variants), so skipping them here would leave unwarmed PSOs for the first
 ## frames of async/API runs.
 static func work_list() -> Array:
+	var configured: Variant = config_work_list()
+	if configured != null:
+		return configured
 	var out: Array = []
 	out.append_array(static_shaders())
 	out.append_array(used_post_shaders())
 	out.append_array(LitShaderLibrary.all_variant_flags())
+	return out
+
+
+## A generated res://lit_precompile.cfg (Project > Tools > Generate Lit Precompile
+## Config) replaces the full work list verbatim: exactly what it names, nothing more.
+## Returns null when the file is absent or unreadable, which means the full build
+## above; delete the file to get back there.
+static func config_work_list() -> Variant:
+	if not FileAccess.file_exists(CONFIG_PATH):
+		return null
+	var cfg := ConfigFile.new()
+	if cfg.load(CONFIG_PATH) != OK:
+		push_warning("Lit: precompile config '%s' failed to parse; running the full precompile" % CONFIG_PATH)
+		return null
+	var out: Array = []
+	for path in cfg.get_value("lit", "shaders", PackedStringArray()):
+		if ResourceLoader.exists(path):
+			out.append(String(path))
+		else:
+			push_warning("Lit: precompile config names a missing shader '%s'; regenerate the config" % path)
+	for name in cfg.get_value("lit", "variants", PackedStringArray()):
+		var flags := LitShaderLibrary.flags_from_variant_name(String(name))
+		if flags >= 0:
+			out.append(flags)
+		else:
+			push_warning("Lit: precompile config names an unknown variant '%s'; regenerate the config" % name)
 	return out
 
 

--- a/docs/release_cut.md
+++ b/docs/release_cut.md
@@ -1,13 +1,13 @@
 # Release Cut
-A release must be tagged prior to uploading to the Asset Library.
+All releases must update the version in `addons/lit/plugin.cfg`
 
+A release must be tagged prior to uploading to the Asset Library.
 ```
 git tag -a v1.1.1 -m "Release v1.1.1"
 git push origin --tags
 ```
 
 For uploading to the asset store, we need an archive of the repo.
-
 ```
 git archive --format=zip --output=release.zip HEAD
 ```


### PR DESCRIPTION
Fix #60

This pull adds a precompilation configuration option. This new editor tool scans an entire project and finds all lit variants which are used and creates a config file: `lit_precompile.cfg`. If this config file exists, the lit shader precompilation startup step will compile only the shaders present in the config instead of running the entire set of lit shaders. This is a vastly more efficient setup step and a useful tool addition.